### PR TITLE
fix: lobby connection interrupt

### DIFF
--- a/crates/ysync/src/server/manager/client_manager.rs
+++ b/crates/ysync/src/server/manager/client_manager.rs
@@ -79,7 +79,7 @@ impl ClientManager {
         self.clients[client_id as usize].as_client()
     }
     pub fn get_clients(&self) -> HashMap<u16, Client> {
-        self.connected_clients.iter().map(|id| (*id, self.clients[*id as usize].client.clone())).collect()
+        self.connected_clients.iter().map(|id| (*id, self.get_client(*id))).collect()
     }
     pub fn inactivate_client(&mut self, addr: IpAddr) -> u16 {
         let client = self.clients.iter_mut().find(|c| c.addr == addr).unwrap();

--- a/crates/ysync/src/tcp_types.rs
+++ b/crates/ysync/src/tcp_types.rs
@@ -18,6 +18,7 @@ pub enum TcpFromClient {
     GameExit,
     GameWorld(#[u16]String),
     Message(String),
+    Heartbeat
 }
 
 #[derive(AsBytes, Debug)]


### PR DESCRIPTION
Clients now send heartbeats every 3s via tcp, so that the server can be sure they are still connected.
If the connection has been interrupted, clients will be disconnected after 60s
solves #11 